### PR TITLE
feat: add networkId in request

### DIFF
--- a/adapters/aduptech/aduptech.go
+++ b/adapters/aduptech/aduptech.go
@@ -76,7 +76,14 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 
 			imp.BidFloorCur = TARGET_CURRENCY
 			imp.BidFloor = convertedValue
+
 		}
+	}
+
+	url, err := a.buildEndpointURL(&imp)
+	if err != nil {
+		errors = append(errors, err)
+		continue
 	}
 
 	requestJSON, err := json.Marshal(request)
@@ -88,12 +95,18 @@ func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 
 	requestData := &adapters.RequestData{
 		Method: "POST",
-		Uri:    a.endpoint,
+		Uri:    url,
 		Body:   requestJSON,
 		ImpIDs: openrtb_ext.GetImpIDs(request.Imp),
 	}
 
 	return []*adapters.RequestData{requestData}, nil
+}
+
+// Builds endpoint url based on adapter-specific pub settings from imp.ext
+func (a *adapter) buildEndpointURL(params *openrtb_ext.ExtImpAduptech) (string, error) {
+	endpointParams := macros.EndpointTemplateParams{publisher: params.PublisherId}
+	return macros.ResolveMacros(a.endpoint, endpointParams)
 }
 
 func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {

--- a/adapters/aduptech/aduptech.go
+++ b/adapters/aduptech/aduptech.go
@@ -1,0 +1,146 @@
+package aduptech
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v2/adapters"
+	"github.com/prebid/prebid-server/v2/config"
+	"github.com/prebid/prebid-server/v2/currency"
+	"github.com/prebid/prebid-server/v2/errortypes"
+	"github.com/prebid/prebid-server/v2/openrtb_ext"
+)
+
+type adapter struct {
+	endpoint   string
+	bidderName string
+}
+
+type BidExt struct {
+	Prebid ExtPrebid `json:"prebid"`
+}
+
+type ExtPrebid struct {
+	BidType     openrtb_ext.BidType `json:"type"`
+	NetworkName string              `json:"networkName"`
+}
+
+type aduptechImpExt struct {
+	Aduptech openrtb_ext.ExtImpAduptech `json:"aduptech"`
+}
+
+const TARGET_CURRENCY = "EUR"
+
+// Builder builds a new instance of the {bidder} adapter for the given bidder with the given config.
+func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
+	bidder := &adapter{
+		endpoint:   config.Endpoint,
+		bidderName: string(bidderName),
+	}
+	return bidder, nil
+}
+
+func (a *adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
+	for i := range request.Imp {
+		imp := &request.Imp[i]
+		// Check if imp comes with bid floor amount defined in a foreign currency
+		if imp.BidFloor > 0 && imp.BidFloorCur != "" && strings.ToUpper(imp.BidFloorCur) != TARGET_CURRENCY {
+
+			// Convert to TARGET_CURRENCY
+			convertedValue, err := reqInfo.ConvertCurrency(imp.BidFloor, imp.BidFloorCur, TARGET_CURRENCY)
+
+			if err != nil {
+				var convErr currency.ConversionNotFoundError
+				if errors.As(err, &convErr) {
+					// try again by first converting to USD
+					convertedValue, err = reqInfo.ConvertCurrency(imp.BidFloor, imp.BidFloorCur, "USD")
+
+					if err != nil {
+						return nil, []error{err}
+					}
+
+					// then convert to TARGET_CURRENCY
+					convertedValue, err = reqInfo.ConvertCurrency(convertedValue, "USD", TARGET_CURRENCY)
+
+					if err != nil {
+						return nil, []error{err}
+					}
+				} else {
+					return nil, []error{err}
+				}
+			}
+
+			imp.BidFloorCur = TARGET_CURRENCY
+			imp.BidFloor = convertedValue
+		}
+	}
+
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	fmt.Println(string(requestJSON))
+
+	requestData := &adapters.RequestData{
+		Method: "POST",
+		Uri:    a.endpoint,
+		Body:   requestJSON,
+		ImpIDs: openrtb_ext.GetImpIDs(request.Imp),
+	}
+
+	return []*adapters.RequestData{requestData}, nil
+}
+
+func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.RequestData, responseData *adapters.ResponseData) (*adapters.BidderResponse, []error) {
+	if responseData.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	if responseData.StatusCode == http.StatusBadRequest {
+		err := &errortypes.BadInput{
+			Message: "Unexpected status code: 400. Run with request.debug = 1 for more info.",
+		}
+		return nil, []error{err}
+	}
+
+	if responseData.StatusCode != http.StatusOK {
+		err := &errortypes.BadServerResponse{
+			Message: fmt.Sprintf("Unexpected status code: %d. Run with request.debug = 1 for more info.", responseData.StatusCode),
+		}
+		return nil, []error{err}
+	}
+
+	var response openrtb2.BidResponse
+	if err := json.Unmarshal(responseData.Body, &response); err != nil {
+		return nil, []error{err}
+	}
+
+	fmt.Println("response: ", response)
+
+	bidResponse := adapters.NewBidderResponse()
+	bidResponse.Currency = response.Cur
+
+	for _, seatBid := range response.SeatBid {
+		for i := range seatBid.Bid {
+			var bidExt BidExt
+			if err := json.Unmarshal(seatBid.Bid[i].Ext, &bidExt); err != nil {
+				return nil, []error{&errortypes.BadServerResponse{
+					Message: fmt.Sprintf("Missing ext.prebid.type in bid for impression : %s.", seatBid.Bid[i].ImpID),
+				}}
+			}
+
+			b := &adapters.TypedBid{
+				Bid:     &seatBid.Bid[i],
+				BidType: "native",
+			}
+			bidResponse.Bids = append(bidResponse.Bids, b)
+		}
+	}
+
+	return bidResponse, nil
+}

--- a/adapters/aduptech/aduptechtest/exemplary/simple-native.json
+++ b/adapters/aduptech/aduptechtest/exemplary/simple-native.json
@@ -1,0 +1,96 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "site": {
+      "page": "https://good.site/url"
+    },
+    "imp": [{
+      "id": "test-imp-id",
+      "native": {
+        "ver": "1.1",
+        "request": "{\"ver\":\"1.0\",\"layout\":1,\"adunit\":1,\"plcmttype\":1,\"plcmtcnt\":1,\"seq\":0,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":75}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":60,\"hmin\":60,\"mimes\":[\"image/jpeg\",\"image/jpg\",\"image/png\"]}},{\"id\":3,\"required\":0,\"data\":{\"type\":2,\"len\":75}},{\"id\":4,\"required\":0,\"data\":{\"type\":6,\"len\":1000}},{\"id\":5,\"required\":0,\"data\":{\"type\":7,\"len\":1000}},{\"id\":6,\"required\":0,\"data\":{\"type\":11,\"len\":1000}}]}"
+      },
+      "ext": {
+        "bidder": {
+          "publisher": "123456",
+          "placement": "234567"
+        }
+      }
+    }]
+  },
+
+  "httpCalls": [{
+    "expectedRequest": {
+      "uri": "https://localhost:5050/rtb/adupsuite_bid",
+      "body": {
+        "id": "test-request-id",
+        "site": {
+          "page": "https://good.site/url"
+        },
+        "imp": [{
+          "id": "test-imp-id",
+          "native": {
+            "ver": "1.1",
+            "request": "{\"ver\":\"1.0\",\"layout\":1,\"adunit\":1,\"plcmttype\":1,\"plcmtcnt\":1,\"seq\":0,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":75}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":60,\"hmin\":60,\"mimes\":[\"image/jpeg\",\"image/jpg\",\"image/png\"]}},{\"id\":3,\"required\":0,\"data\":{\"type\":2,\"len\":75}},{\"id\":4,\"required\":0,\"data\":{\"type\":6,\"len\":1000}},{\"id\":5,\"required\":0,\"data\":{\"type\":7,\"len\":1000}},{\"id\":6,\"required\":0,\"data\":{\"type\":11,\"len\":1000}}]}"
+          },
+          "ext": {
+            "bidder": {
+              "publisher": "123456",
+              "placement": "234567"
+            }
+          }
+        }]
+      },
+      "impIDs":["test-imp-id"]
+    },
+    "mockResponse": {
+      "status": 200,
+      "body": {
+        "id": "test-request-id",
+        "seatbid": [{
+          "seat": "grid",
+          "bid": [{
+            "id": "randomid",
+            "impid": "test-imp-id",
+            "price": 0.500000,
+            "adid": "12345678",
+            "adm": "{\"ver\":\"1.0\",\"layout\":1,\"adunit\":1,\"plcmttype\":1,\"plcmtcnt\":1,\"seq\":0,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":75}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":60,\"hmin\":60,\"mimes\":[\"image/jpeg\",\"image/jpg\",\"image/png\"]}},{\"id\":3,\"required\":0,\"data\":{\"type\":2,\"len\":75}},{\"id\":4,\"required\":0,\"data\":{\"type\":6,\"len\":1000}},{\"id\":5,\"required\":0,\"data\":{\"type\":7,\"len\":1000}},{\"id\":6,\"required\":0,\"data\":{\"type\":11,\"len\":1000}}]}",
+            "ext": {
+              "prebid": {
+                "type": "native"
+              }
+            },
+            "cid": "987",
+            "crid": "12345678",
+            "h": 250,
+            "w": 300
+          }]
+        }],
+        "cur": "USD"
+      }
+    }
+  }],
+
+  "expectedBidResponses": [{
+    "currency": "USD",
+    "bids": [{
+      "bid": {
+        "id": "randomid",
+        "impid": "test-imp-id",
+        "price": 0.5,
+        "adm": "{\"ver\":\"1.0\",\"layout\":1,\"adunit\":1,\"plcmttype\":1,\"plcmtcnt\":1,\"seq\":0,\"assets\":[{\"id\":1,\"required\":1,\"title\":{\"len\":75}},{\"id\":2,\"required\":1,\"img\":{\"type\":3,\"wmin\":60,\"hmin\":60,\"mimes\":[\"image/jpeg\",\"image/jpg\",\"image/png\"]}},{\"id\":3,\"required\":0,\"data\":{\"type\":2,\"len\":75}},{\"id\":4,\"required\":0,\"data\":{\"type\":6,\"len\":1000}},{\"id\":5,\"required\":0,\"data\":{\"type\":7,\"len\":1000}},{\"id\":6,\"required\":0,\"data\":{\"type\":11,\"len\":1000}}]}",
+        "adid": "12345678",
+        "cid": "987",
+        "crid": "12345678",
+        "w": 300,
+        "h": 250,
+        "ext": {
+          "prebid": {
+            "type": "native"
+          }
+        }
+      },
+      "type": "native"
+    }]
+  }]
+}

--- a/adapters/aduptech/aduptechtest/exemplary/simple-native.json
+++ b/adapters/aduptech/aduptechtest/exemplary/simple-native.json
@@ -21,7 +21,7 @@
 
   "httpCalls": [{
     "expectedRequest": {
-      "uri": "https://localhost:5050/rtb/adupsuite_bid",
+      "uri": "https://localhost:5050/bid/publisher=123456",
       "body": {
         "id": "test-request-id",
         "site": {

--- a/adapters/aduptech/params_test.go
+++ b/adapters/aduptech/params_test.go
@@ -1,0 +1,56 @@
+package aduptech
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/prebid-server/v2/openrtb_ext"
+)
+
+var validParams = []string{
+	`{ "publisher": "123456789", "placement": "234567890" }`,
+	`{ "publisher": "123456789", "placement": "234567890", "query": "test" }`,
+	`{ "publisher": "123456789", "placement": "234567890", "query": "test", "adtest": true }`,
+}
+
+func TestValidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, validParam := range validParams {
+		if err := validator.Validate(openrtb_ext.BidderAdUpTech, json.RawMessage(validParam)); err != nil {
+			t.Errorf("Schema rejected Aduptech params: %s", validParam)
+		}
+	}
+}
+
+var invalidParams = []string{
+	``,
+	`null`,
+	`true`,
+	`5`,
+	`4.2`,
+	`[]`,
+	`{}`,
+	`{ "publisher": "123456789" }`,
+	`{ "placement": "234567890" }`,
+	`{ "publisher": "", "placement": "" }`,
+	`{ "publisher": null, "placement": null }`,
+	`{ "publisher": "123456789", "placement": "234567890", "query": null }`,
+	`{ "publisher": "123456789", "placement": "234567890", "adtest": null }`,
+}
+
+func TestInvalidParams(t *testing.T) {
+	validator, err := openrtb_ext.NewBidderParamsValidator("../../static/bidder-params")
+	if err != nil {
+		t.Fatalf("Failed to fetch the json-schemas. %v", err)
+	}
+
+	for _, invalidParam := range invalidParams {
+		if err := validator.Validate(openrtb_ext.BidderAdtrgtme, json.RawMessage(invalidParam)); err == nil {
+			t.Errorf("Schema allowed unexpected params: %s", invalidParam)
+		}
+	}
+}

--- a/exchange/adapter_builders.go
+++ b/exchange/adapter_builders.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prebid/prebid-server/v2/adapters/adtelligent"
 	"github.com/prebid/prebid-server/v2/adapters/adtonos"
 	"github.com/prebid/prebid-server/v2/adapters/adtrgtme"
+	"github.com/prebid/prebid-server/v2/adapters/aduptech"
 	"github.com/prebid/prebid-server/v2/adapters/advangelists"
 	"github.com/prebid/prebid-server/v2/adapters/adview"
 	"github.com/prebid/prebid-server/v2/adapters/adxcg"
@@ -257,6 +258,7 @@ func newAdapterBuilders() map[openrtb_ext.BidderName]adapters.Builder {
 		openrtb_ext.BidderAdtrgtme:          adtrgtme.Builder,
 		openrtb_ext.BidderAdtelligent:       adtelligent.Builder,
 		openrtb_ext.BidderAdTonos:           adtonos.Builder,
+		openrtb_ext.BidderAdUpTech:          aduptech.Builder,
 		openrtb_ext.BidderAdvangelists:      advangelists.Builder,
 		openrtb_ext.BidderAdView:            adview.Builder,
 		openrtb_ext.BidderAdxcg:             adxcg.Builder,

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -44,6 +44,7 @@ var coreBidderNames []BidderName = []BidderName{
 	BidderAdtrgtme,
 	BidderAdtelligent,
 	BidderAdTonos,
+	BidderAdUpTech,
 	BidderAdvangelists,
 	BidderAdView,
 	BidderAdxcg,
@@ -373,6 +374,7 @@ const (
 	BidderAdtrgtme          BidderName = "adtrgtme"
 	BidderAdTonos           BidderName = "adtonos"
 	BidderAdtelligent       BidderName = "adtelligent"
+	BidderAdUpTech          BidderName = "aduptech"
 	BidderAdvangelists      BidderName = "advangelists"
 	BidderAdView            BidderName = "adview"
 	BidderAdxcg             BidderName = "adxcg"

--- a/openrtb_ext/imp_aduptech.go
+++ b/openrtb_ext/imp_aduptech.go
@@ -1,0 +1,8 @@
+package openrtb_ext
+
+type ExtImpAduptech struct {
+	PublisherId string `json:"publisher"`
+	PlacementId string `json:"placement"`
+	Query       string `json:"query"`
+	AdTest      string `json:"adtest"`
+}

--- a/static/bidder-info/aduptech.yaml
+++ b/static/bidder-info/aduptech.yaml
@@ -1,0 +1,26 @@
+endpoint: "https://rtb.adup-tech.com/rtb/adupsuite_bid"
+endpointCompression: gzip
+geoscope:
+  - DEU
+  - AUT
+  - CHE
+  - FRA
+  - GBR
+  - NED
+  - ESP
+maintainer:
+  email: "support@adup-tech.com"
+gvlVendorID: 647
+capabilities:
+  app:
+    mediaTypes:
+      - banner
+      - native
+  site:
+    mediaTypes:
+      - banner
+      - native
+userSync:
+  redirect:
+    url: "https://rtb.adup-tech.com/service/usersync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/aduptech.yaml
+++ b/static/bidder-info/aduptech.yaml
@@ -1,4 +1,4 @@
-endpoint: "https://rtb.adup-tech.com/rtb/adupsuite_bid"
+endpoint: "https://rtb.adup-tech.com/bid/publisher={{.publisher}}"
 endpointCompression: gzip
 geoscope:
   - DEU

--- a/static/bidder-params/aduptech.json
+++ b/static/bidder-params/aduptech.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "AdUp Tech adapter params",
+    "description": "A schema which validates params accepted by the AdUp Tech adapter",
+    "type": "object",
+  
+    "properties": {
+      "publisher": {
+        "type": "string",
+        "description": "Unique publisher identifier"
+      },
+      "placement": {
+        "type": "string",
+        "description": "Unique placement identifier per publisher"
+      },
+      "query": {
+        "type": "string",
+        "description": "Semicolon separated list of keywords"
+      },
+      "adtest": {
+        "type": "boolean",
+        "description": "Deactivates tracking of impressions and clicks. **Should only be used for testing purposes!**"
+      }
+    },
+  
+    "required": ["publisher", "placement"]
+  }


### PR DESCRIPTION
The idea is to create a new Rtb-Route: "extern"
The network-id provided is the network id from our actual Network table.

A publisher has to know which network it belongs to. If it does not, it ain't no publisher of ours.